### PR TITLE
add /describe command for stage directions

### DIFF
--- a/src/TwoDays.tsx
+++ b/src/TwoDays.tsx
@@ -42,8 +42,13 @@ export default function TwoDays() {
             <MessagePoster workspace={currentWorkspace} />
           </section>
           <section id="help">
-            <div><b>/me</b> looks at the sky.</div>
-            <div><b>/describe</b> The sun sets.</div>
+            <details>
+              <summary>Commands</summary>
+              <ul>
+                <li><b>/me</b> looks at the sky. &rarr; <b>MyName</b> looks at the sky.</li>
+                <li><b>/describe</b> The sun sets. &rarr; <i>The sun sets.</i></li>
+              </ul>
+            </details>
           </section>
         </>
       ) : (
@@ -183,8 +188,8 @@ function ActionisedMessage({
     "author-f",
   ]);
 
-  const isAuthorAction = messageDoc.content.startsWith("/me ");
-  const isDescribeAction = messageDoc.content.startsWith("/describe ");
+  const isAuthorAction = messageDoc.content.startsWith("/me");
+  const isDescribeAction = messageDoc.content.startsWith("/describe");
   const [displayNameDoc] = useDocument(
     workspace,
     `/about/~${messageDoc.author}/displayName.txt`
@@ -203,13 +208,13 @@ function ActionisedMessage({
   if (isAuthorAction) {
     return <div className="author-action">
       <em>
-        {name} {messageDoc.content.replace("/me ", "")}
+        {name}{messageDoc.content.replace("/me", "")}
       </em>
     </div>
   } else if (isDescribeAction) {
     return <div className="describe-action">
       <em title={messageDoc.author}>
-        {messageDoc.content.replace("/describe ", "")}
+        {messageDoc.content.replace("/describe", "")}
       </em>
     </div>
   } else {

--- a/src/TwoDays.tsx
+++ b/src/TwoDays.tsx
@@ -41,6 +41,10 @@ export default function TwoDays() {
             <MessageList workspace={currentWorkspace} />
             <MessagePoster workspace={currentWorkspace} />
           </section>
+          <section id="help">
+            <div><b>/me</b> looks at the sky.</div>
+            <div><b>/describe</b> The sun sets.</div>
+          </section>
         </>
       ) : (
         <div>
@@ -179,7 +183,8 @@ function ActionisedMessage({
     "author-f",
   ]);
 
-  const isAction = messageDoc.content.startsWith("/me ");
+  const isAuthorAction = messageDoc.content.startsWith("/me ");
+  const isDescribeAction = messageDoc.content.startsWith("/describe ");
   const [displayNameDoc] = useDocument(
     workspace,
     `/about/~${messageDoc.author}/displayName.txt`
@@ -195,20 +200,26 @@ function ActionisedMessage({
     </span>
   );
 
-  return isAction ? (
-    <div id={"author-action"}>
+  if (isAuthorAction) {
+    return <div className="author-action">
       <em>
-        {name} {messageDoc.content.replace("/me", "")}
+        {name} {messageDoc.content.replace("/me ", "")}
       </em>
     </div>
-  ) : (
-    <div id={"author-speech"}>
+  } else if (isDescribeAction) {
+    return <div className="describe-action">
+      <em title={messageDoc.author}>
+        {messageDoc.content.replace("/describe ", "")}
+      </em>
+    </div>
+  } else {
+    return <div className="author-speech">
       {name}
       {" says “"}
       {messageDoc.content}
       {"”"}
     </div>
-  );
+  }
 }
 
 const START_FADING_MINUTES = 360;
@@ -266,9 +277,7 @@ function MessagePoster({ workspace }: { workspace: string }) {
       }}
     >
       <input
-        placeholder={
-          "Speak out at the crossing! Prefix with /me to perform an action"
-        }
+        placeholder="Speak out at the crossing!"
         value={messageValue}
         onChange={(e) => setMessageValue(e.target.value)}
       />

--- a/src/twodays.css
+++ b/src/twodays.css
@@ -19,6 +19,8 @@ body {
   background-position: center;
 
   scrollbar-color: var(--main-colour) var(--other-colour);
+
+  min-height: 95vh;
 }
 
 #twodays-app {
@@ -54,9 +56,15 @@ header aside {
 
 #help {
   padding-top: 16px;
+  padding-left: 8px;
   color: var(--main-colour);
-  opacity: 0.5;
+}
+
+#help summary {
   text-align: center;
+}
+#help ul {
+  list-style-type: none;
 }
 
 #preamble {

--- a/src/twodays.css
+++ b/src/twodays.css
@@ -52,6 +52,13 @@ header aside {
   overflow: hidden;
 }
 
+#help {
+  padding-top: 16px;
+  color: var(--main-colour);
+  opacity: 0.5;
+  text-align: center;
+}
+
 #preamble {
   padding: 8px 0 0 0;
 }
@@ -75,9 +82,15 @@ header aside {
   resize: vertical;
 }
 
-#author-action,
-#author-speech {
+.author-action,
+.describe-action,
+.author-speech {
   margin: 0 0 0.5em 0;
+}
+
+.describe-action {
+  text-align: center;
+  color: var(--main-colour);
 }
 
 .author-a {
@@ -115,6 +128,11 @@ header aside {
   border-top: 3px solid var(--main-colour);
   background-color: var(--other-colour);
   padding: 8px;
+  font-size: inherit;
+  font-family: inherit;
+}
+#posting-input input::placeholder {
+  color: var(--main-colour);
 }
 
 #posting-input button {


### PR DESCRIPTION
Adds `/describe` which lets you speak stage directions without a username:

`/describe Snow blows.`  -->   *Snow blows.*

Also show help about slash commands below the chat area now that there are two of them (`/me` and `/describe`)

I also changed the text input font to match the rest of the fonts on the page.

![Screen Shot 2020-12-02 at 9 22 28 PM](https://user-images.githubusercontent.com/32660718/100967629-8a280b00-34e4-11eb-897d-b727d6990f6f.png)