### PR TITLE
Include tilde in path to set author permissions

### DIFF
--- a/src/TwoDays.tsx
+++ b/src/TwoDays.tsx
@@ -241,7 +241,7 @@ function MessagePoster({ workspace }: { workspace: string }) {
   const [messageValue, setMessageValue] = React.useState("");
   const [currentAuthor] = useCurrentAuthor();
 
-  const path = `/twodays-v1.0/${currentAuthor?.address}/${Date.now()}.txt!`;
+  const path = `/twodays-v1.0/~${currentAuthor?.address}/${Date.now()}.txt!`;
 
   const [, setDoc] = useDocument(workspace, path);
 


### PR DESCRIPTION
Add missing `~` to paths to enforce author permissions.

The old paths will continue to work after this, but new ones will be created with tildes.