### PR TITLE
Skip blank messages and prevent their creation; sort before scrolling

### DIFF
--- a/src/TwoDays.tsx
+++ b/src/TwoDays.tsx
@@ -136,20 +136,20 @@ function MessageList({ workspace }: { workspace: string }) {
 
   const docs = useDocuments(workspace, {
     pathPrefix: "/twodays-v1.0/",
+    contentIsEmpty: false,
   });
 
-  const lastDoc = docs[docs.length - 1];
+  // sort oldest first
+  docs.sort((aDoc, bDoc) => (aDoc.timestamp < bDoc.timestamp ? -1 : 1));
 
-  const lastDocId = lastDoc?.contentHash ?? "none";
+  const lastDoc = docs[docs.length - 1];
+  const lastDocId = lastDoc?.path ?? "none";
 
   React.useEffect(() => {
     if (messagesRef.current) {
       messagesRef.current.scrollTop = messagesRef.current.scrollHeight;
     }
   }, [lastDocId]);
-
-  // 'Good enough' sorting
-  docs.sort((aDoc, bDoc) => (aDoc.timestamp < bDoc.timestamp ? -1 : 1));
 
   return (
     <>
@@ -257,9 +257,11 @@ function MessagePoster({ workspace }: { workspace: string }) {
       onSubmit={(e) => {
         e.preventDefault();
 
+        if (messageValue.trim().length === 0) { return; }
+
         setDoc(
-          messageValue,
-          Date.now() * 1000 + 24 * 60 * 60 * 1000 * 2 * 1000
+          messageValue.trim(),
+          (Date.now() * 1000) + 2 * 24 * 60 * 60 * 1000 * 1000
         );
 
         setMessageValue("");


### PR DESCRIPTION
* Prevent people from posting empty strings
* Skip existing messages that are empty strings
* The scroll-to-last-message code now happens after sorting the messages.  (I'm not sure why this wasn't showing up as a problem in real life?)
* Use document's path as the hook key instead of contentHash.  (Many docs could have the same contentHash if they had the same content.)