### PR TITLE
Colors change with the seasons

### DIFF
--- a/src/TwoDays.tsx
+++ b/src/TwoDays.tsx
@@ -15,6 +15,8 @@ export default function TwoDays() {
   const [currentWorkspace] = useCurrentWorkspace();
   let [hourOf] = useHourOf();
 
+  document.body.className = hourOf.season; //todo: useEffect hook?
+
   return (
     <div id={"twodays-app"}>
       {currentWorkspace ? (
@@ -38,7 +40,7 @@ export default function TwoDays() {
                 }
               </p>
               <p className="seasonal-hour">
-                It is the {hourOf.longName}.
+                It is the {hourOf.longName} in {hourOf.season}.
               </p>
             </aside>
           </header>

--- a/src/twodays.css
+++ b/src/twodays.css
@@ -9,6 +9,8 @@
   --char-d-colour: #114c8a;
   --char-e-colour: #4d00aa;
   --char-f-colour: #880060;
+  --transition-props: color, background, border-color;
+  --transition-time: 3s;
 }
 
 body.winter {
@@ -41,6 +43,9 @@ body {
   scrollbar-color: var(--main-colour) var(--other-colour);
 
   min-height: 95vh;
+
+  transition-property: var(--transition-props);
+  transition-duration: var(--transition-time);
 }
 
 #twodays-app {
@@ -67,6 +72,9 @@ header aside {
 
 .seasonal-hour {
   color: var(--main-colour);
+
+  transition-property: var(--transition-props);
+  transition-duration: var(--transition-time);
 }
 
 #panel {
@@ -76,12 +84,18 @@ header aside {
   display: flex;
   flex-direction: column;
   overflow: hidden;
+
+  transition-property: var(--transition-props);
+  transition-duration: var(--transition-time);
 }
 
 #help {
   padding-top: 16px;
   padding-left: 8px;
   color: var(--main-colour);
+
+  transition-property: var(--transition-props);
+  transition-duration: var(--transition-time);
 }
 
 #help summary {
@@ -99,11 +113,17 @@ header aside {
   color: var(--main-colour);
   display: block;
   padding: 0 8px;
+
+  transition-property: var(--transition-props);
+  transition-duration: var(--transition-time);
 }
 
 #preamble hr {
   border: 1px solid var(--main-colour);
   margin: 8px 0 2px 0;
+
+  transition-property: var(--transition-props);
+  transition-duration: var(--transition-time);
 }
 
 #author-messages {
@@ -112,6 +132,9 @@ header aside {
   padding: 8px;
   background: var(--other-colour);
   resize: vertical;
+
+  transition-property: var(--transition-props);
+  transition-duration: var(--transition-time);
 }
 
 .author-action,
@@ -123,6 +146,9 @@ header aside {
 .describe-action {
   text-align: center;
   color: var(--main-colour);
+
+  transition-property: var(--transition-props);
+  transition-duration: var(--transition-time);
 }
 
 .author-a {
@@ -162,9 +188,15 @@ header aside {
   padding: 8px;
   font-size: inherit;
   font-family: inherit;
+
+  transition-property: var(--transition-props);
+  transition-duration: var(--transition-time);
 }
 #posting-input input::placeholder {
   color: var(--main-colour);
+
+  transition-property: var(--transition-props);
+  transition-duration: var(--transition-time);
 }
 
 #posting-input button {
@@ -177,6 +209,9 @@ header aside {
   font-size: 1em;
   font-family: "Georgia";
   padding: 8px;
+
+  transition-property: var(--transition-props);
+  transition-duration: var(--transition-time);
 }
 
 /* Earthbar styling */
@@ -187,6 +222,9 @@ header aside {
   padding: 11px;
   border-bottom: 3px solid var(--main-colour);
   position: relative;
+
+  transition-property: var(--transition-props);
+  transition-duration: var(--transition-time);
 }
 
 [data-react-earthstar-earthbar] h2 {
@@ -195,6 +233,9 @@ header aside {
 
 [data-react-earthstar-earthbar] a {
   color: var(--char-b-colour);
+
+  transition-property: var(--transition-props);
+  transition-duration: var(--transition-time);
 }
 
 [data-react-earthstar-earthbar-tabs] {
@@ -212,6 +253,9 @@ header aside {
   text-decoration-thickness: 2px;
   margin: 0 1px;
   display: inline-block;
+
+  transition-property: var(--transition-props);
+  transition-duration: var(--transition-time);
 }
 
 [data-react-earthstar-earthbar-panel][role="tabpanel"] {
@@ -225,7 +269,10 @@ header aside {
   left: 0;
   right: 0;
   box-shadow: 2px 2px 10px 5px rgba(0, 0, 0, 0.2);
-  z-index: 10
+  z-index: 10;
+
+  transition-property: var(--transition-props);
+  transition-duration: var(--transition-time);
 }
 
 [data-react-earthstar-button] {
@@ -237,6 +284,9 @@ header aside {
   font-weight: bold;
   border-radius: 10px;
   border: none;
+
+  transition-property: var(--transition-props);
+  transition-duration: var(--transition-time);
 }
 
 [data-react-earthstar-input] {
@@ -246,6 +296,9 @@ header aside {
   color: var(--other-colour);
   border: 1px solid var(--other-colour);
   padding: 4px;
+
+  transition-property: var(--transition-props);
+  transition-duration: var(--transition-time);
 }
 
 [data-react-earthstar-details] {

--- a/src/twodays.css
+++ b/src/twodays.css
@@ -11,6 +11,26 @@
   --char-f-colour: #880060;
 }
 
+body.winter {
+  --main-colour: #1e1a42;
+  --other-colour: #deebff;
+}
+
+body.spring {
+  --main-colour: #2a562a;
+  --other-colour: #ecfff4;
+}
+
+body.summer {
+  --main-colour: #293b52;
+  --other-colour: #fffdcc;
+}
+
+body.fall {
+  --main-colour: #664249;
+  --other-colour: #f7f0ed;
+}
+
 body {
   font-family: "Georgia";
   background-color: var(--other-colour);
@@ -46,7 +66,7 @@ header aside {
 }
 
 .seasonal-hour {
-  color: var(--char-a-colour);
+  color: var(--main-colour);
 }
 
 #panel {
@@ -212,8 +232,8 @@ header aside {
   font-family: Georgia;
   font-size: 14px;
   padding: 6px;
-  background: var(--char-b-colour);
-  color: var(--other-colour);
+  background: var(--other-colour);
+  color: var(--main-colour);
   font-weight: bold;
   border-radius: 10px;
   border: none;


### PR DESCRIPTION
* The hour name announcement also states the current season. 
* The colors change according to the season.
* There is a 3 second transition between seasons =)

This branch is currently deployed at https://twodays-crossing.herokuapp.com/ .

Here's what the seasons look like! Ignore that they all say "autumn" in the hour announcement. I took these screenshots by changing the class name in the inspect window. =)
![twodays-crossing seasonal colors](https://user-images.githubusercontent.com/315395/101391359-0de14f00-3879-11eb-8231-0719aadb0c9c.png)

Grabbing `document.body` is probably not very react-ish, so I'd love to hear how it can be improved (@cinnamon-bun thinks `useEffect`?). 

The season colors are loosely based on the [hour name brainstorming doc](https://docs.google.com/spreadsheets/d/1uEnIJp2FFQYr2VexcZvJhKOMe898lOUDCrXZX2VlzDQ/edit#gid=0). cinn and I picked main-colours that were closer to dark, and other-colours that weren't saturated.

(Edited to add: netlify's deploy-preview feature is cool! I don't need a separate staging server!)